### PR TITLE
Fixing data format in read_csv

### DIFF
--- a/ims/gcims.py
+++ b/ims/gcims.py
@@ -268,10 +268,10 @@ class Spectrum:
         """
         name = os.path.split(path)[1]
         name = name.split(".")[0]
-        df = pd.read_csv(path)
+        df = pd.read_csv(path, index_col = [0])
         values = df.values
-        ret_time = df.index
-        drift_time = df.columns
+        ret_time = np.array(df.index)
+        drift_time = df.columns.to_numpy().astype(float)
         timestamp = os.path.getctime(path)
         timestamp = ctime(timestamp)
         timestamp = datetime.strptime(timestamp, "%a %b  %d %H:%M:%S %Y")


### PR DESCRIPTION
By using read_csv method, data imported from the csv file are saved as a DataFrame with:

- df.index as a RangeIndex object of integer values [0,1,2,..] instead of retention times as float numbers,
- this affects the retention time values which should be a numpy array, and
- also the drift time values creating an Index object with drift times as 'object' dtype.
 
With this pull request,

- The index of the created DataFrame is now in the correct format,
- The retention and the drift time values are converted to numpy arrays.