### PR TITLE
[feature] add theoretical Q quantile for PCA

### DIFF
--- a/ims/pca.py
+++ b/ims/pca.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 from matplotlib.ticker import MaxNLocator, AutoMinorLocator
 from sklearn.decomposition import PCA
-from scipy.stats import f
+from scipy.stats import f, norm
 
 
 class PCA_Model:
@@ -73,7 +73,7 @@ class PCA_Model:
         self.svd_solver = svd_solver
         self._sk_pca = PCA(n_components, svd_solver=svd_solver, **kwargs)
 
-    def fit(self, X_train):
+    def fit(self, X_train, conf_level=0.95, theoretical_quantiles=True):
         """
         Fit the PCA model with training data.
 
@@ -81,6 +81,11 @@ class PCA_Model:
         ----------
         X_train : numpy.ndarray of shape (n_samples, n_features)
             The training data.
+        conf_level : float, optional
+            Confidence level for Tsq/Q outlier detection, by default 0.95.
+        theoretical_quantiles : bool, optional
+            Use theoretical quantiles for Tsq/Q outlier detection,
+            by default True. If False, empirical quantiles are used.
 
         Returns
         -------
@@ -97,13 +102,24 @@ class PCA_Model:
         self.residuals = X_train - self.scores @ self.loadings
         self.Q = np.sum(self.residuals**2, axis=1)
         self.Tsq = np.sum((self.scores / np.std(self.scores, axis=0)) ** 2, axis=1)
-        self.Tsq_conf = (
-            f.ppf(q=0.95, dfn=self.n_components, dfd=self.scores.shape[0])
-            * self.n_components
-            * (self.scores.shape[0] - 1)
-            / (self.scores.shape[0] - self.n_components)
-        )
-        self.Q_conf = np.quantile(self.Q, q=0.95)
+        if theoretical_quantiles:
+            # theoretical quantile for T2, according to Hotelling statistics (which is a scaled F distribution)
+            self.Tsq_conf = (
+                f.ppf(q=conf_level, dfn=self.n_components, dfd=self.scores.shape[0])
+                * self.n_components
+                * (self.scores.shape[0] - 1)
+                / (self.scores.shape[0] - self.n_components)
+            )
+            # theoretical quantile for Q, according to Jackson and Mudholkar (1979), Eq. (3.4)
+            lambda_ = np.linalg.eigvals(np.cov(X_train, rowvar=False))
+            theta = {i: np.sum(np.power(lambda_[len(self.explained_variance):], i)) for i in [1,2,3]}
+            h0 = 1 - 2 * theta[1] * theta[3] / (3 * theta[2]**2)
+            self.Q_conf = theta[1] * (1
+                                      + norm.ppf(conf_level) * np.sqrt(2 * theta[2] * h0**2) / theta[1]
+                                      + theta[2]*h0*(h0-1) / theta[1]**2)**(1/h0)
+        else:
+            self.Tsq_conf = np.quantile(self.Tsq, q=conf_level)
+            self.Q_conf = np.quantile(self.Q, q=conf_level)
         return self
 
     def plot(self, PC_x=1, PC_y=2, annotate=False):


### PR DESCRIPTION
Hi Joscha & Cathy,
see my mail from today: I had some time to think about the Q residual quantile issue. Think I solved it once and for all (at least for PCA/SIMCA), see my conclusion here:
https://github.com/s-sauer/PCA_residual_quantiles/blob/main/T2-Q-Quantile_emp_vs_theo.ipynb

I also added the (in)famous formula by for the theoretical Q-quantile by Jackson and Mudholkar (1979) to pca.py in the gc-imc-toolbox. Warning: It's only tested in my own jupyter notebook, not within pca.py

If you like it, you can merge it into the toolbox. Cheers!