### PR TITLE
Add normalization methods

### DIFF
--- a/ims/dataset.py
+++ b/ims/dataset.py
@@ -616,6 +616,31 @@ class Dataset:
             labels=labels,
         )
 
+    def normalization(self):
+        """
+        Normalizes each spectrum in the dataset by scaling its intensity values to the range [0, 1].
+
+        This method ensures that the intensity values of each spectrum are individually normalized 
+        between 0 and 1 based on their unique minimum and maximum values. This standardizes the 
+        dataset, facilitating consistent comparison and analysis across different spectra.
+
+        Example
+        -------
+        >>> import ims
+        >>> ds = ims.Dataset.read_mea("IMS_data")
+        >>> ds.normalization()
+
+        Returns
+        -------
+        self : Dataset
+            The dataset with normalized spectra.
+        """
+
+        self.data = [Spectrum.normalize_spectrum(i) for i in self.data]
+        self.preprocessing.append("normalization")
+        
+        return self
+
     def add_spectrum(self, spectrum, sample, label):
         """
         Adds a ims.Spectrum to the dataset.

--- a/ims/gcims.py
+++ b/ims/gcims.py
@@ -344,6 +344,35 @@ class Spectrum:
             f.attrs["name"] = self.name
             f.attrs["time"] = datetime.strftime(self.time, "%Y-%m-%dT%H:%M:%S")
             f.attrs["drift_time_label"] = self._drift_time_label
+    
+    def normalize_spectrum(self):
+        """
+        Normalize a single spectrum by scaling its values to the range [0, 1].
+
+        Example
+        -------
+        >>> import ims
+        >>> sample = ims.Spectrum.read_mea("sample.mea")
+        >>> sample.normalize_spectrum()
+
+        Returns
+        -------
+        self : Spectrum
+            The spectrum with normalized values.
+        """
+
+        # Find the minimum and maximum values of the intensity values
+        min_value = np.min(self.values)
+        max_value = np.max(self.values)
+
+        # Normalize the intensity values to the range [0, 1]
+        if max_value > min_value:
+            self.values = (self.values - min_value) / (max_value - min_value)
+        # Raise Error
+        else:
+            raise ValueError(f"Spectrum {self.name} cannot be normalized because it has constant or zero values.")
+
+        return self
 
     def find_peaks(self, limit=None, denoise="fastnl", window=30, verbose=0):
         """


### PR DESCRIPTION
Adding two methods for data normalization to the Spectrum and Dataset classes:

-**normalize_spectrum** (added to the **Spectrum** class):
Scales the intensity values of a single spectrum to the range [0, 1], ensuring each spectrum is independently normalized using its unique minimum and maximum values.

-**normalization** (added to the **Dataset** class):
Normalizes all spectra in the dataset by scaling their intensity values to the range [0, 1], ensuring consistency and comparability across the dataset.